### PR TITLE
Add suricata version info to index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -100,3 +100,9 @@ sources:
     license: GPLv3
     url: https://raw.githubusercontent.com/travisbgreen/hunting-rules/master/hunting.rules
     min-version: 4.1.0
+
+versions:
+
+  suricata:
+    recommended: 4.1.4
+    "4.1": 4.1.4


### PR DESCRIPTION
The recommended and supported version info for suricata is made
part of the index.

Link to Redmine: https://redmine.openinfosecfoundation.org/issues/2341