### PR TITLE
checksum: use checksum: true|false instead of no-checksum

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -24,7 +24,7 @@ sources:
         prompt: Emerging Threats Pro access code
     replaces:
       - et/open
-    no-checksum: true
+    checksum: false
 
   oisf/trafficid:
     summary: Suricata Traffic ID ruleset
@@ -33,7 +33,7 @@ sources:
     url: https://openinfosecfoundation.org/rules/trafficid/trafficid.rules
     support-url: https://redmine.openinfosecfoundation.org/
     min-version: 4.0.0
-    no-checksum: true
+    checksum: false
 
   ptresearch/attackdetection:
     summary: Positive Technologies Attack Detection Team ruleset
@@ -77,7 +77,7 @@ sources:
     vendor: Abuse.ch
     license: Non-Commercial
     url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules
-    no-checksum: true
+    checksum: false
 
   sslbl/ja3-fingerprints:
     summary: Abuse.ch Suricata JA3 Fingerprint Ruleset
@@ -87,7 +87,7 @@ sources:
     license: Non-Commercial
     url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.rules
     min-version: 4.1.0
-    no-checksum: true
+    checksum: false
 
   etnetera/aggressive:
     summary: Etnetera aggressive IP blacklist
@@ -95,7 +95,7 @@ sources:
     license: MIT
     url: https://security.etnetera.cz/feeds/etn_aggressive.rules
     min-version: 4.0.0
-    no-checksum: true
+    checksum: false
 
   tgreen/hunting:
     summary: Threat hunting rules
@@ -105,7 +105,7 @@ sources:
     license: GPLv3
     url: https://raw.githubusercontent.com/travisbgreen/hunting-rules/master/hunting.rules
     min-version: 4.1.0
-    no-checksum: true
+    checksum: false
 
 versions:
   suricata:


### PR DESCRIPTION
Currently Suricata-Update still assumes a checksum exists, and
is an md5 checksum. This can be set to false to indicate there
is not a checksum-url.