### PR TITLE
abuse.ch: rename ssl and ja3 blacklists - v1

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -83,7 +83,7 @@ sources:
     subscribe-url: https://www.secureworks.com/contact/ (Please reference CTU Countermeasures)
     min-version: 3.0.0
 
-  sslbl/ssl-fp-blacklist:
+  abuse.ch/ssl-blacklist: &abuse-ch-ssl-blacklist
     summary: Abuse.ch SSL Blacklist
     description: |
       The SSL Blacklist (SSLBL) is a project of abuse.ch with the goal of detecting malicious SSL connections, by identifying and blacklisting SSL certificates used by botnet C&C servers. In addition, SSLBL identifies JA3 fingerprints that helps you to detect & block malware botnet C&C communication on the TCP layer.
@@ -92,7 +92,13 @@ sources:
     url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules
     checksum: false
 
-  sslbl/ja3-fingerprints:
+  # This is here for compatibility as this entry was renamed to
+  # abuse.ch/ssl-blacklist.
+  sslbl/ssl-fp-blacklist:
+    << : *abuse-ch-ssl-blacklist
+    deprecated: Renamed to abuse.sh/ssl-blacklist
+
+  abuse.sh/ja3-blacklist: &abuse-ch-ja3-blacklist
     summary: Abuse.ch Suricata JA3 Fingerprint Ruleset
     description: |
       If you are running Suricata, you can use the SSLBL's Suricata JA3 FingerprintRuleset to detect and/or block malicious SSL connections in your network based on the JA3 fingerprint. Please note that your need Suricata 4.1.0 or newer in order to use the JA3 fingerprint ruleset.
@@ -101,6 +107,10 @@ sources:
     url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.rules
     min-version: 4.1.0
     checksum: false
+
+  sslbl/ja3-fingerprints:
+    << : *abuse-ch-ja3-blacklist
+    deprecated: Renamed to abuse.ch/ja3-blacklist
 
   etnetera/aggressive:
     summary: Etnetera aggressive IP blacklist


### PR DESCRIPTION
Rename the following abuse.ch rulesets:
- sslbl/ssl-fp-blacklist -> abuse.ch/ssl-blacklist
- sslbl/ja3-fingerprints -> abuse.ch/ja3-blacklist

This keeps the old entries around to keep compatibility with older
versions of suricata-update, but marks them as deprecated which
newer suricata-update will recognize and suppress from listing.