### PR TITLE
versions: update for 6.0.2, 5.0.6

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -122,7 +122,6 @@ sources:
 
 versions:
   suricata:
-    recommended: 6.0.1
-    "6.0": 6.0.1
-    "5.0": 5.0.5
-    "4.1": 4.1.10
+    recommended: 6.0.2
+    "6.0": 6.0.2
+    "5.0": 5.0.6


### PR DESCRIPTION
Remove 4.1 as its now EOL.

~~Prepping as I'd like the updated index to be embedded in the suricata-update that is released with 6.0.2.~~