### PR TITLE
ptresearch: mark as obsolete

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -43,6 +43,7 @@ sources:
     license: Custom
     license-url: https://raw.githubusercontent.com/ptresearch/AttackDetection/master/LICENSE
     url: https://raw.githubusercontent.com/ptresearch/AttackDetection/master/pt.rules.tar.gz
+    obsolete: no longer exists
 
   scwx/enhanced:
     summary: Secureworks suricata-enhanced ruleset


### PR DESCRIPTION
This ruleset is gone from GitHub. Mark it as obsolete so Suricata-Update
will stop trying to download it.