### PR TITLE
abusech/updates/v2

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -157,6 +157,19 @@ sources:
     url: https://sslbl.abuse.ch/blacklist/sslipblacklist.tar.gz
     checksum: false
 
+  abuse.ch/feodotracker:
+    summary: Abuse.ch Feodo Tracker Botnet C2 IP ruleset
+    description: |
+      The Suricata Botnet C2 IP Ruleset contains botnet C2s tracked by
+      Feodo Tracker and can be used for both, Suricata and Snort open
+      source IDS/IPS. If you are running Suricata or Snort, you can
+      use this ruleset to detect and/or block network connections
+      towards hostline servers (IP address:port combination).
+    vendor: Abuse.ch
+    license: CC0-1.0
+    url: https://feodotracker.abuse.ch/downloads/feodotracker.tar.gz
+    checksum: false
+
   etnetera/aggressive:
     summary: Etnetera aggressive IP blacklist
     vendor: Etnetera a.s.

--- a/index.yaml
+++ b/index.yaml
@@ -84,24 +84,67 @@ sources:
     subscribe-url: https://www.secureworks.com/contact/ (Please reference CTU Countermeasures)
     min-version: 3.0.0
 
-  sslbl/ssl-fp-blacklist:
+  abuse.ch/sslbl-blacklist:
     summary: Abuse.ch SSL Blacklist
     description: |
-      The SSL Blacklist (SSLBL) is a project of abuse.ch with the goal of detecting malicious SSL connections, by identifying and blacklisting SSL certificates used by botnet C&C servers. In addition, SSLBL identifies JA3 fingerprints that helps you to detect & block malware botnet C&C communication on the TCP layer.
+      The SSL Blacklist (SSLBL) is a project of abuse.ch with the goal
+      of detecting malicious SSL connections, by identifying and
+      blacklisting SSL certificates used by botnet C&C servers. In
+      addition, SSLBL identifies JA3 fingerprints that helps you to
+      detect & block malware botnet C&C communication on the TCP
+      layer.
     vendor: Abuse.ch
     license: CC0-1.0
     url: https://sslbl.abuse.ch/blacklist/sslblacklist_tls_cert.tar.gz
     checksum: false
+    replaces: sslbl/ssl-fp-blacklist
 
-  sslbl/ja3-fingerprints:
+  # Deprecated in favor of abuse.ch/sslbl-blacklist.
+  sslbl/ssl-fp-blacklist:
+    summary: Abuse.ch SSL Blacklist
+    description: |
+      The SSL Blacklist (SSLBL) is a project of abuse.ch with the goal
+      of detecting malicious SSL connections, by identifying and
+      blacklisting SSL certificates used by botnet C&C servers. In
+      addition, SSLBL identifies JA3 fingerprints that helps you to
+      detect & block malware botnet C&C communication on the TCP
+      layer.
+    vendor: Abuse.ch
+    license: CC0-1.0
+    url: https://sslbl.abuse.ch/blacklist/sslblacklist_tls_cert.tar.gz
+    checksum: false
+    deprecated: Renamed to abuse.ch/sslbl-blacklist
+
+  abuse.ch/sslbl-ja3:
     summary: Abuse.ch Suricata JA3 Fingerprint Ruleset
     description: |
-      If you are running Suricata, you can use the SSLBL's Suricata JA3 FingerprintRuleset to detect and/or block malicious SSL connections in your network based on the JA3 fingerprint. Please note that your need Suricata 4.1.0 or newer in order to use the JA3 fingerprint ruleset.
+      If you are running Suricata, you can use the SSLBL's Suricata
+      JA3 fingerprint ruleset to detect and/or block malicious SSL
+      connections in your network based on the JA3 fingerprint. Please
+      note that your need Suricata 4.1.0 or newer in order to use the
+      JA3 fingerprint ruleset.
     vendor: Abuse.ch
     license: CC0-1.0
     url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.tar.gz
     min-version: 4.1.0
     checksum: false
+    replaces: sslbl/ja3-fingerprints
+
+  # Deprecated in favor of abuse.ch/sslbl-ja3
+  sslbl/ja3-fingerprints:
+    summary: Abuse.ch Suricata JA3 Fingerprint Ruleset
+    description: |
+      If you are running Suricata, you can use the SSLBL's Suricata
+      JA3 fingerprint ruleset to detect and/or block malicious SSL
+      connections in your network based on the JA3 fingerprint. Please
+      note that your need Suricata 4.1.0 or newer in order to use the
+      JA3 fingerprint ruleset.
+    vendor: Abuse.ch
+    license: CC0-1.0
+    url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.tar.gz
+    min-version: 4.1.0
+    checksum: false
+    deprecated: Renamed to abuse.ch/sslbl-ja3
 
   etnetera/aggressive:
     summary: Etnetera aggressive IP blacklist

--- a/index.yaml
+++ b/index.yaml
@@ -89,7 +89,7 @@ sources:
     description: |
       The SSL Blacklist (SSLBL) is a project of abuse.ch with the goal of detecting malicious SSL connections, by identifying and blacklisting SSL certificates used by botnet C&C servers. In addition, SSLBL identifies JA3 fingerprints that helps you to detect & block malware botnet C&C communication on the TCP layer.
     vendor: Abuse.ch
-    license: Non-Commercial
+    license: CC0-1.0
     url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules
     checksum: false
 
@@ -98,7 +98,7 @@ sources:
     description: |
       If you are running Suricata, you can use the SSLBL's Suricata JA3 FingerprintRuleset to detect and/or block malicious SSL connections in your network based on the JA3 fingerprint. Please note that your need Suricata 4.1.0 or newer in order to use the JA3 fingerprint ruleset.
     vendor: Abuse.ch
-    license: Non-Commercial
+    license: CC0-1.0
     url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.rules
     min-version: 4.1.0
     checksum: false

--- a/index.yaml
+++ b/index.yaml
@@ -99,7 +99,7 @@ sources:
       If you are running Suricata, you can use the SSLBL's Suricata JA3 FingerprintRuleset to detect and/or block malicious SSL connections in your network based on the JA3 fingerprint. Please note that your need Suricata 4.1.0 or newer in order to use the JA3 fingerprint ruleset.
     vendor: Abuse.ch
     license: CC0-1.0
-    url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.rules
+    url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.tar.gz
     min-version: 4.1.0
     checksum: false
 

--- a/index.yaml
+++ b/index.yaml
@@ -90,7 +90,7 @@ sources:
       The SSL Blacklist (SSLBL) is a project of abuse.ch with the goal of detecting malicious SSL connections, by identifying and blacklisting SSL certificates used by botnet C&C servers. In addition, SSLBL identifies JA3 fingerprints that helps you to detect & block malware botnet C&C communication on the TCP layer.
     vendor: Abuse.ch
     license: CC0-1.0
-    url: https://sslbl.abuse.ch/blacklist/sslblacklist.rules
+    url: https://sslbl.abuse.ch/blacklist/sslblacklist_tls_cert.tar.gz
     checksum: false
 
   sslbl/ja3-fingerprints:

--- a/index.yaml
+++ b/index.yaml
@@ -146,6 +146,17 @@ sources:
     checksum: false
     deprecated: Renamed to abuse.ch/sslbl-ja3
 
+  abuse.ch/sslbl-c2:
+    summary: Abuse.ch Suricata Botnet C2 IP Ruleset
+    description: |
+      This ruleset contains all botnet Command&Control servers (C&Cs)
+      identified by SSLBL to be associated with a blacklisted SSL
+      certificate.
+    vendor: Abuse.ch
+    license: CC0-1.0
+    url: https://sslbl.abuse.ch/blacklist/sslipblacklist.tar.gz
+    checksum: false
+
   etnetera/aggressive:
     summary: Etnetera aggressive IP blacklist
     vendor: Etnetera a.s.

--- a/index.yaml
+++ b/index.yaml
@@ -170,6 +170,16 @@ sources:
     url: https://feodotracker.abuse.ch/downloads/feodotracker.tar.gz
     checksum: false
 
+  abuse.ch/urlhaus:
+    summary: Abuse.ch URLhaus Suricata Rules
+    description: |
+      URLhaus is a project from abuse.ch with the goal of sharing
+      malicious URLs that are being used for malware distribution.
+    vendor: abuse.ch
+    url: https://urlhaus.abuse.ch/downloads/urlhaus_suricata.tar.gz
+    license: CC0-1.0
+    checksum: false
+
   etnetera/aggressive:
     summary: Etnetera aggressive IP blacklist
     vendor: Etnetera a.s.


### PR DESCRIPTION
- **sslbl: update license to CC0 (CC0-1.0)**
- **sslbl/blacklist: update to more modern URL**
- **sslbl/ja3-fingerprints: use .tar.gz URL**
- **sslbl: deprecated in favor of new abuse.ch namespace**
- **ruleset: abuse.ch botnet c2 ip ruleset**
- **ruleset: abuse.ch/feodotracker**
- **ruleset: add abuse.ch urlhaus ruleset**
