### PR TITLE
nmap: add nmap ruleset

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -319,6 +319,19 @@ sources:
     checksum: false
     license: CC-BY-SA-4.0
 
+  opnsense-nmap:
+    summary: OPNSense's Suricata IDS/IPS Detection Rules Against NMAP Scans
+    description: |
+      These detection rules work by looking for specific NMAP
+      packet window sizes, flags, port numbers, and known NMAP
+      timing intervals.
+    homepage: https://github.com/aleksibovellan/opnsense-suricata-nmaps
+    vendor: aleksibovellan
+    min-version: 7.0.4
+    url: https://raw.githubusercontent.com/aleksibovellan/opnsense-suricata-nmaps/main/local.rules
+    checksum: false
+    license: MIT
+
 versions:
   suricata:
     recommended: 7.0.6


### PR DESCRIPTION
This PR adds an index entry for "OPNSense's Suricata IDS/IPS Detection Rules Against NMAP Scans" (https://github.com/aleksibovellan/opnsense-suricata-nmaps).

AFAICS it is suitable for here because:

* it is available openly from GitHub,
* it is published under a free license (MIT)
* it publishes its rules in an allocated SID range (3400000-3499999).