### PR TITLE
ci: add validation action

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,24 @@
+---
+
+name: YAML Validation
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  yamllint:
+    name: 'yamllint'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Yamllint'
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: index.yaml
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  truthy:
+    check-keys: false

--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,5 @@
+---
+
 # This is a version 1 formatted index.
 version: 1
 


### PR DESCRIPTION
This PR adds simple YAML syntax validation as a GitHub Action. It uses `yamllint` to check the syntax of the `index.yaml` file containing the index. Both merges to master and pull requests will be checked, and findings in the latter will be posted as comments to the respective PR.

Opinionated checks like maximum line length enforcement have been disabled.