### PR TITLE
nmap: add nmap source v2

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -319,6 +319,19 @@ sources:
     checksum: false
     license: CC-BY-SA-4.0
 
+  aleksibovellan/nmap:
+    summary: Suricata IDS/IPS Detection Rules Against NMAP Scans
+    description: |
+      These detection rules work by looking for specific NMAP
+      packet window sizes, flags, port numbers, and known NMAP
+      timing intervals.
+    homepage: https://github.com/aleksibovellan/opnsense-suricata-nmaps
+    vendor: aleksibovellan
+    min-version: 7.0.4
+    url: https://raw.githubusercontent.com/aleksibovellan/opnsense-suricata-nmaps/main/local.rules
+    checksum: false
+    license: MIT
+
 versions:
   suricata:
     recommended: 7.0.6


### PR DESCRIPTION
Previous PR: #22 

Changes compared to previous PR:

* Changed ruleset name to no longer reference OPNsense since upstream has no direct relation.