### PR TITLE
ci: add validation action -- v2

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,24 @@
+---
+
+name: YAML Validation
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  yamllint:
+    name: 'yamllint'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Yamllint'
+        uses: karancode/yamllint-github-action@master
+        with:
+          yamllint_file_or_dir: index.yaml
+          yamllint_comment: true
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  truthy:
+    check-keys: false
+  document-start:
+    present: false


### PR DESCRIPTION
Previous PR: #23 

Changes to previous PR:
* Do not require YAML document start in `index.yaml`.
* Run CI on pushes to all branches.