### PR TITLE
abuse.ch ruleset: fix replaces syntax

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -97,7 +97,8 @@ sources:
     license: CC0-1.0
     url: https://sslbl.abuse.ch/blacklist/sslblacklist_tls_cert.tar.gz
     checksum: false
-    replaces: sslbl/ssl-fp-blacklist
+    replaces:
+      - sslbl/ssl-fp-blacklist
 
   # Deprecated in favor of abuse.ch/sslbl-blacklist.
   sslbl/ssl-fp-blacklist:
@@ -128,7 +129,8 @@ sources:
     url: https://sslbl.abuse.ch/blacklist/ja3_fingerprints.tar.gz
     min-version: 4.1.0
     checksum: false
-    replaces: sslbl/ja3-fingerprints
+    replaces:
+      - sslbl/ja3-fingerprints
 
   # Deprecated in favor of abuse.ch/sslbl-ja3
   sslbl/ja3-fingerprints:


### PR DESCRIPTION
The "replaces" key is supposed to be a list. That is how it is interpreted by suricata-update and is used across other sources using it. Fix the yaml syntax to make the entries a list.