### PR TITLE
malsilo: mark as obsolete

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -210,6 +210,7 @@ sources:
     min-version: 4.1.0
     homepage: https://raw-data.gitlab.io/post/malsilo_2.1/
     checksum: true
+    obsolete: unmaintained
 
   stamus/lateral:
     summary: Lateral movement rules


### PR DESCRIPTION
Ruleset is no longer maintained, and the SID range is being removed due
to overlaps with others.
