### PR TITLE
abuse.ch/sslbl-c2: deprecated

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -158,6 +158,7 @@ sources:
     license: CC0-1.0
     url: https://sslbl.abuse.ch/blacklist/sslipblacklist.tar.gz
     checksum: false
+    deprecated: Deprecated by source on 2025-01-03.
 
   abuse.ch/feodotracker:
     summary: Abuse.ch Feodo Tracker Botnet C2 IP ruleset

--- a/index.yaml
+++ b/index.yaml
@@ -348,5 +348,6 @@ sources:
 
 versions:
   suricata:
-    recommended: 7.0.10
-    "7.0": 7.0.10
+    recommended: 8.0.0
+    "7.0": 7.0.11
+    "8.0": 8.0.0


### PR DESCRIPTION
From the source:

  ATTENTION: This list has been deprecated on 2025-01-03
