### PR TITLE
Add IPFire DBL

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -347,6 +347,18 @@ sources:
     checksum: false
     license: MIT
 
+  ipfire/dbl:
+    summary: IPFire DBL
+    description: |
+      IPFire DBL is a comprehensive, community-maintained domain blocklist
+      that protects your network from malware, phishing, unwanted content, and emerging threats
+    homepage: https://www.ipfire.org/dbl/
+    vendor: IPFire
+    min-version: 6.0.0
+    url: https://dbl.ipfire.org/lists/suricata.tar.gz
+    checksum: false
+    license: CC BY-SA 4.0
+
 versions:
   suricata:
     recommended: 8.0.3


### PR DESCRIPTION
Hello,

please add IPFire DBL as a rule source for everyone.

More information about IPFire DBL is available at https://www.ipfire.org/dbl and on our blog:

* https://www.ipfire.org/blog/introducing-ipfire-dbl-community-powered-domain-blocking-for-everyone
* https://www.ipfire.org/blog/beyond-dns-ipfire-dbl-suricata-close-the-filtering-gap