### PR TITLE
Add source: the-hunters-ledger/open

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -371,6 +371,19 @@ sources:
     min-version: 7.0.0
     checksum: false
 
+  the-hunters-ledger/open:
+    summary: The Hunters Ledger threat-intelligence detection feed
+    description: |
+      Community Suricata ruleset derived from original malware and open-directory
+      investigations published at the-hunters-ledger.com. Updated as new
+      campaigns are analyzed.
+    vendor: The Hunters Ledger
+    license: CC-BY-4.0
+    url: https://the-hunters-ledger.com/feeds/suricata/hunters-ledger.rules
+    homepage: https://the-hunters-ledger.com/
+    support-url: https://the-hunters-ledger.com/hunting-detections/
+    min-version: 8.0.0
+
 versions:
   suricata:
     recommended: 8.0.5


### PR DESCRIPTION
Adds The Hunters Ledger's open Suricata detection feed as a source.

- **Feed:** https://the-hunters-ledger.com/feeds/suricata/hunters-ledger.rules — a consolidated, openly-licensed ruleset (102 rules) derived from original malware and open-directory investigations published at the-hunters-ledger.com, updated as new campaigns are analyzed.
- **SID range:** uses the dedicated block `3500000`–`3509999` allocated via sidallocation.org, so no collisions with other rulesets.
- **License:** CC-BY-4.0.
- **min-version:** 8.0.0 (rules are validated against Suricata 8.0.5).

Entry added under `sources:` in `index.yaml`. Happy to adjust any field.
