### PR TITLE
versions: remove 7.0, it is now EOL

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -388,5 +388,4 @@ sources:
 versions:
   suricata:
     recommended: 8.0.6
-    "7.0": 7.0.17
     "8.0": 8.0.6


### PR DESCRIPTION
The "check-versions" command will now tell users that their 7.0 build is
EOL.
